### PR TITLE
Make examples work with Metal Performance Shaders

### DIFF
--- a/main_test_fbcnn_color.py
+++ b/main_test_fbcnn_color.py
@@ -44,8 +44,13 @@ def main():
         logger = logging.getLogger(logger_name)
         logger.info('--------------- quality factor: {:d} ---------------'.format(quality_factor))
 
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         border = 0
+        if torch.cuda.is_available():
+            device = torch.device('cuda')
+        elif torch.backends.mps.is_available():
+            device = torch.device('mps')
+        else:
+            device = torch.device('cpu')
 
 
         # ----------------------------------------

--- a/main_test_fbcnn_gray.py
+++ b/main_test_fbcnn_gray.py
@@ -43,8 +43,13 @@ def main():
         logger = logging.getLogger(logger_name)
         logger.info('--------------- quality factor: {:d} ---------------'.format(quality_factor))
 
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         border = 0
+        if torch.cuda.is_available():
+            device = torch.device('cuda')
+        elif torch.backends.mps.is_available():
+            device = torch.device('mps')
+        else:
+            device = torch.device('cpu')
 
 
         # ----------------------------------------

--- a/main_test_fbcnn_gray_doublejpeg.py
+++ b/main_test_fbcnn_gray_doublejpeg.py
@@ -44,8 +44,13 @@ def main():
             logger = logging.getLogger(logger_name)
             logger.info('--------------- QF1={:d}, QF2={:d} ---------------'.format(qf1,qf2))
 
-            device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
             border = 0
+            if torch.cuda.is_available():
+                device = torch.device('cuda')
+            elif torch.backends.mps.is_available():
+                device = torch.device('mps')
+            else:
+                device = torch.device('cpu')
 
 
             # ----------------------------------------


### PR DESCRIPTION
This works fine with Metal Performance Shaders, but the included examples/tests fallback to the CPU as soon as CUDA isn't available. This PR makes them prioritize CUDA, then MPS, then CPU fallback.

**Note**: Not tested on Apple Silicon or macOS 13+.

Test environment:
```
GPU:           Radeon RX 6000 8GB
OS:            macOS 12.7.4 (Metal 2)
Python:        3.11.8
torch:         2.2.2
torchvision:   0.17.2
opencv-python: 4.9.0.80
numpy:         1.26.4
```